### PR TITLE
Enhance orchestrator planning and execution

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,8 +1,11 @@
 """FastAPI surface for the Themis orchestrator."""
 
+from __future__ import annotations
+
 from fastapi import FastAPI
 
-from orchestrator.router import router as orchestrator_router
+from orchestrator.router import configure_service, router as orchestrator_router
+from orchestrator.service import OrchestratorService
 
 app = FastAPI(title="Themis Orchestrator API")
 
@@ -10,9 +13,9 @@ app = FastAPI(title="Themis Orchestrator API")
 @app.on_event("startup")
 async def startup() -> None:
     """Perform startup initialization hooks."""
-    # Load orchestrator configuration, register agents, warm caches, etc.
-    # Implementations should replace this stub with real startup logic.
-    pass
+    service = OrchestratorService()
+    configure_service(service)
+    app.state.orchestrator_service = service
 
 
 app.include_router(orchestrator_router, prefix="/orchestrator", tags=["orchestrator"])

--- a/orchestrator/router.py
+++ b/orchestrator/router.py
@@ -1,20 +1,71 @@
 """Routing layer exposing orchestrator operations via FastAPI."""
 
-from fastapi import APIRouter
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, ConfigDict
 
 from orchestrator.service import OrchestratorService
 
 router = APIRouter()
-service = OrchestratorService()
+_service: OrchestratorService | None = None
+
+
+class PlanRequest(BaseModel):
+    """Request payload for planning operations."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    matter: dict[str, Any]
+
+
+class ExecuteRequest(BaseModel):
+    """Request payload for executing previously generated plans."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    plan_id: str | None = None
+    matter: dict[str, Any] | None = None
+
+
+def configure_service(service: OrchestratorService) -> None:
+    """Register the orchestrator service instance used by the router."""
+
+    global _service
+    _service = service
+
+
+def get_service() -> OrchestratorService:
+    """Return the configured orchestrator service, creating one if missing."""
+
+    global _service
+    if _service is None:
+        _service = OrchestratorService()
+    return _service
 
 
 @router.post("/plan", summary="Create an execution plan for a legal matter")
-async def plan(matter: dict) -> dict:
+async def plan(request: PlanRequest) -> dict[str, Any]:
     """Generate a draft plan given a matter payload."""
-    return await service.plan(matter)
+
+    service = get_service()
+    return await service.plan(request.matter)
 
 
 @router.post("/execute", summary="Run a plan through registered agents")
-async def execute(matter: dict) -> dict:
+async def execute(request: ExecuteRequest) -> dict[str, Any]:
     """Run a matter through the orchestrated workflow."""
-    return await service.execute(matter)
+
+    if request.plan_id is None and request.matter is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Provide either an existing plan_id or a matter payload to execute.",
+        )
+
+    service = get_service()
+    try:
+        return await service.execute(plan_id=request.plan_id, matter=request.matter)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc

--- a/orchestrator/service.py
+++ b/orchestrator/service.py
@@ -2,37 +2,165 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
+from uuid import uuid4
 
+from agents.base import AgentProtocol
+from agents.dea import DEAAgent
+from agents.lda import LDAAgent
+from agents.lsa import LSAAgent
 from orchestrator.state import OrchestratorState
 
 
 class OrchestratorService:
-    """Skeleton service that wires agent planning and execution."""
+    """Service responsible for planning and executing agent workflows."""
 
-    def __init__(self) -> None:
+    def __init__(self, agents: dict[str, AgentProtocol] | None = None) -> None:
         self.state = OrchestratorState()
+        self.agents = agents or {
+            "lda": LDAAgent(),
+            "dea": DEAAgent(),
+            "lsa": LSAAgent(),
+        }
+        self._default_plan = (
+            (
+                "lda",
+                "Extract facts and figures from the supplied matter payload.",
+                [
+                    {
+                        "name": "fact_pattern_summary",
+                        "description": "Structured summary of key facts and timeline details.",
+                    }
+                ],
+            ),
+            (
+                "dea",
+                "Apply doctrinal analysis over the fact pattern to surface legal issues.",
+                [
+                    {
+                        "name": "legal_theories",
+                        "description": "List of legal theories and supporting authorities.",
+                    }
+                ],
+            ),
+            (
+                "lsa",
+                "Craft negotiation and settlement strategy leveraging prior analysis.",
+                [
+                    {
+                        "name": "negotiation_strategy",
+                        "description": "Proposed negotiation framing, demands, and concessions.",
+                    }
+                ],
+            ),
+        )
 
     async def plan(self, matter: dict[str, Any]) -> dict[str, Any]:
-        """Create a placeholder plan until the planner is implemented."""
-        return {
+        """Create an executable plan across the registered agents."""
+        plan_id = str(uuid4())
+        steps: list[dict[str, Any]] = []
+        previous_step_id: str | None = None
+
+        for index, (agent_name, description, expected_artifacts) in enumerate(self._default_plan, start=1):
+            step_id = f"step-{index}"
+            dependencies = [previous_step_id] if previous_step_id else []
+            steps.append(
+                {
+                    "id": step_id,
+                    "agent": agent_name,
+                    "description": description,
+                    "status": "pending",
+                    "inputs": {
+                        "matter": matter,
+                        "dependencies": dependencies,
+                    },
+                    "dependencies": dependencies,
+                    "expected_artifacts": expected_artifacts,
+                }
+            )
+            previous_step_id = step_id
+
+        plan: dict[str, Any] = {
+            "plan_id": plan_id,
             "status": "planned",
-            "inputs": matter,
-            "steps": [
-                {"agent": "lda", "task": "Extract facts and figures."},
-                {"agent": "dea", "task": "Apply doctrinal analysis."},
-                {"agent": "lsa", "task": "Craft negotiation strategy."},
-            ],
+            "matter": matter,
+            "steps": steps,
         }
 
-    async def execute(self, matter: dict[str, Any]) -> dict[str, Any]:
-        """Execute the placeholder plan returning mocked artifacts."""
-        plan = await self.plan(matter)
-        return {
-            "status": "complete",
-            "plan": plan,
-            "artifacts": {
-                "timeline": "TODO: generate timeline exhibit",
-                "demand_letter": "TODO: generate demand letter",
-            },
+        self.state.remember_plan(plan_id, deepcopy(plan))
+        return plan
+
+    async def execute(
+        self,
+        matter: dict[str, Any] | None = None,
+        plan_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Execute a plan by invoking each registered agent in order."""
+
+        if plan_id is not None:
+            plan = self.state.recall_plan(plan_id)
+            if plan is None:
+                raise ValueError(f"Plan '{plan_id}' does not exist")
+            if matter is not None:
+                plan["matter"] = matter
+                self.state.remember_plan(plan_id, deepcopy(plan))
+        else:
+            if matter is None:
+                raise ValueError("Matter payload is required when no plan_id is provided")
+            plan = await self.plan(matter)
+            plan_id = plan["plan_id"]
+
+        plan_matter = plan.get("matter", {})
+        steps_results: list[dict[str, Any]] = []
+        artifacts: dict[str, Any] = {}
+        overall_status = "complete"
+
+        for step in plan["steps"]:
+            agent_name = step["agent"]
+            agent = self.agents.get(agent_name)
+            step_result: dict[str, Any] = {
+                "id": step["id"],
+                "agent": agent_name,
+                "dependencies": step.get("dependencies", []),
+                "expected_artifacts": step.get("expected_artifacts", []),
+            }
+
+            if agent is None:
+                step_result["status"] = "failed"
+                step_result["error"] = f"Agent '{agent_name}' is not registered"
+                overall_status = "failed"
+                step["status"] = "failed"
+                step["error"] = step_result["error"]
+                steps_results.append(step_result)
+                continue
+
+            try:
+                output = await agent.run(plan_matter)
+            except Exception as exc:  # pragma: no cover - defensive programming
+                step_result["status"] = "failed"
+                step_result["error"] = str(exc)
+                overall_status = "failed"
+                step["status"] = "failed"
+                step["error"] = step_result["error"]
+            else:
+                step_result["status"] = "complete"
+                step_result["output"] = output
+                artifacts[agent_name] = output
+                step["status"] = "complete"
+                step["output"] = output
+
+            steps_results.append(step_result)
+
+        execution_record = {
+            "plan_id": plan_id,
+            "status": overall_status,
+            "steps": steps_results,
+            "artifacts": artifacts,
         }
+
+        plan["status"] = overall_status
+        self.state.remember_plan(plan_id, deepcopy(plan))
+        self.state.remember_execution(plan_id, deepcopy(execution_record))
+
+        return execution_record

--- a/orchestrator/state.py
+++ b/orchestrator/state.py
@@ -11,11 +11,29 @@ class OrchestratorState:
     """In-memory state for orchestration scaffolding."""
 
     memory: dict[str, Any] = field(default_factory=dict)
+    plans: dict[str, dict[str, Any]] = field(default_factory=dict)
+    executions: dict[str, dict[str, Any]] = field(default_factory=dict)
 
     def remember(self, key: str, value: Any) -> None:
-        """Persist information into the shared memory."""
+        """Persist miscellaneous information into the shared memory."""
         self.memory[key] = value
 
     def recall(self, key: str, default: Any | None = None) -> Any | None:
         """Retrieve a value stored in memory."""
         return self.memory.get(key, default)
+
+    def remember_plan(self, plan_id: str, plan: dict[str, Any]) -> None:
+        """Persist a plan definition for later execution."""
+        self.plans[plan_id] = plan
+
+    def recall_plan(self, plan_id: str) -> dict[str, Any] | None:
+        """Retrieve a plan definition by identifier."""
+        return self.plans.get(plan_id)
+
+    def remember_execution(self, plan_id: str, execution: dict[str, Any]) -> None:
+        """Persist the results of executing a plan."""
+        self.executions[plan_id] = execution
+
+    def recall_execution(self, plan_id: str) -> dict[str, Any] | None:
+        """Retrieve an execution record by the associated plan identifier."""
+        return self.executions.get(plan_id)


### PR DESCRIPTION
## Summary
- register core agents within the orchestrator service and persist structured plans/executions in shared state
- orchestrate plan creation and execution with detailed step metadata and agent outputs
- expose richer plan and execution responses through the API and initialize the orchestrator service during startup

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68f52eb9b6888332854fbf03a79adb84