### PR TITLE
Add SQLite persistence for orchestrator state

### DIFF
--- a/orchestrator/router.py
+++ b/orchestrator/router.py
@@ -69,3 +69,25 @@ async def execute(request: ExecuteRequest) -> dict[str, Any]:
         return await service.execute(plan_id=request.plan_id, matter=request.matter)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+@router.get("/plans/{plan_id}", summary="Retrieve a previously generated plan")
+async def get_plan(plan_id: str) -> dict[str, Any]:
+    """Fetch a plan definition by identifier."""
+
+    service = get_service()
+    try:
+        return await service.get_plan(plan_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+@router.get("/artifacts/{plan_id}", summary="Retrieve execution artifacts for a plan")
+async def get_artifacts(plan_id: str) -> dict[str, Any]:
+    """Fetch artifacts generated during execution for a plan."""
+
+    service = get_service()
+    try:
+        return await service.get_artifacts(plan_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc

--- a/orchestrator/storage/__init__.py
+++ b/orchestrator/storage/__init__.py
@@ -1,0 +1,5 @@
+"""Persistence backends for orchestrator state."""
+
+from .sqlite_repository import SQLiteOrchestratorStateRepository
+
+__all__ = ["SQLiteOrchestratorStateRepository"]

--- a/orchestrator/storage/sqlite_repository.py
+++ b/orchestrator/storage/sqlite_repository.py
@@ -1,0 +1,79 @@
+"""SQLite-backed persistence for orchestrator state using SQLModel."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import Column, JSON
+from sqlmodel import Field, Session, SQLModel, create_engine
+
+from orchestrator.state import OrchestratorState
+
+
+class OrchestratorStateRecord(SQLModel, table=True):
+    """SQLModel mapping for persisting orchestrator state."""
+
+    key: str = Field(default="singleton", primary_key=True)
+    memory: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    plans: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    executions: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+
+
+class SQLiteOrchestratorStateRepository:
+    """Repository persisting orchestrator state to a SQLite database."""
+
+    def __init__(self, database_url: str = "sqlite:///./orchestrator_state.db") -> None:
+        self.engine = create_engine(database_url, echo=False)
+        SQLModel.metadata.create_all(self.engine)
+
+    def load_state(self) -> OrchestratorState:
+        """Load the orchestrator state from storage."""
+
+        with Session(self.engine) as session:
+            record = session.get(OrchestratorStateRecord, "singleton")
+            if record is None:
+                return OrchestratorState()
+            return OrchestratorState(
+                memory=dict(record.memory or {}),
+                plans=dict(record.plans or {}),
+                executions=dict(record.executions or {}),
+            )
+
+    def save_state(self, state: OrchestratorState) -> None:
+        """Persist the orchestrator state to storage."""
+
+        payload = {
+            "memory": dict(state.memory),
+            "plans": dict(state.plans),
+            "executions": dict(state.executions),
+        }
+
+        with Session(self.engine) as session:
+            record = session.get(OrchestratorStateRecord, "singleton")
+            if record is None:
+                record = OrchestratorStateRecord(key="singleton", **payload)
+            else:
+                record.memory = payload["memory"]
+                record.plans = payload["plans"]
+                record.executions = payload["executions"]
+
+            session.add(record)
+            session.commit()
+
+    def clear(self) -> None:
+        """Remove any persisted orchestrator state."""
+
+        with Session(self.engine) as session:
+            record = session.get(OrchestratorStateRecord, "singleton")
+            if record is not None:
+                session.delete(record)
+                session.commit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "uvicorn[standard]>=0.24",
   "pydantic>=2.5",
   "pyyaml>=6.0",
+  "sqlmodel>=0.0.16",
 ]
 
 [project.optional-dependencies]

--- a/tests/orchestrator/test_service_persistence.py
+++ b/tests/orchestrator/test_service_persistence.py
@@ -1,0 +1,69 @@
+"""Integration tests for orchestrator service persistence."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from orchestrator.service import OrchestratorService
+from orchestrator.storage.sqlite_repository import SQLiteOrchestratorStateRepository
+
+
+class DummyAgent:
+    """Minimal agent implementation for testing."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    async def run(self, matter: dict[str, Any]) -> dict[str, Any]:
+        return {"agent": self.name, "matter": matter}
+
+
+@pytest.fixture
+def dummy_agents() -> dict[str, DummyAgent]:
+    return {name: DummyAgent(name) for name in ("lda", "dea", "lsa")}
+
+
+@pytest.mark.asyncio
+async def test_plan_and_execution_are_persisted(tmp_path, dummy_agents):
+    database_url = f"sqlite:///{tmp_path/'orchestrator.db'}"
+    repository = SQLiteOrchestratorStateRepository(database_url=database_url)
+    service = OrchestratorService(agents=dummy_agents, repository=repository)
+
+    matter = {"case": "example"}
+    plan = await service.plan(matter)
+    plan_id = plan["plan_id"]
+
+    execution = await service.execute(plan_id=plan_id)
+    assert execution["status"] == "complete"
+    assert set(execution["artifacts"]) == {"lda", "dea", "lsa"}
+
+    reloaded_service = OrchestratorService(
+        agents=dummy_agents,
+        repository=SQLiteOrchestratorStateRepository(database_url=database_url),
+    )
+
+    stored_plan = await reloaded_service.get_plan(plan_id)
+    assert stored_plan["plan_id"] == plan_id
+    artifacts = await reloaded_service.get_artifacts(plan_id)
+    assert set(artifacts) == set(execution["artifacts"])
+
+
+@pytest.mark.asyncio
+async def test_missing_plan_raises_error(tmp_path, dummy_agents):
+    database_url = f"sqlite:///{tmp_path/'orchestrator.db'}"
+    service = OrchestratorService(
+        agents=dummy_agents,
+        repository=SQLiteOrchestratorStateRepository(database_url=database_url),
+    )
+
+    with pytest.raises(ValueError):
+        await service.get_plan("unknown-plan")
+
+    with pytest.raises(ValueError):
+        await service.get_artifacts("unknown-plan")


### PR DESCRIPTION
## Summary
- introduce a SQLModel-backed SQLite repository for orchestrator state persistence
- update the orchestrator service to load and save plans/executions through the repository and expose history lookups
- extend the API router with endpoints for retrieving stored plans and execution artifacts, and add integration tests for persistence

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68f66535ec448332a5e6a43f5c4add23