### PR TITLE
Add agent telemetry instrumentation and metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@
 4. [Getting Started](#getting-started)
 5. [Usage Patterns](#usage-patterns)
 6. [Development Guide](#development-guide)
-7. [Roadmap](#roadmap)
-8. [Contributing](#contributing)
-9. [License](#license)
+7. [Observability & Metrics](#observability--metrics)
+8. [Roadmap](#roadmap)
+9. [Contributing](#contributing)
+10. [License](#license)
 
 ---
 
@@ -136,6 +137,25 @@ Implement the `AgentProtocol` (see `agents/base.py`) and register the agent in t
 1. Create fixtures under `packs/<pack_name>/fixtures/`.
 2. Author QA scenarios in `qa/<pack_name>/`.
 3. Run `make qa PACK=<pack_name>` to validate.
+
+---
+
+## Observability & Metrics
+
+Structured telemetry is available via the orchestrator API once agents begin processing matters. The `/metrics` endpoint emits [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/) text describing agent performance:
+
+```bash
+# With the API running locally on the default port
+curl -s http://localhost:8000/metrics | grep themis_agent
+```
+
+Key series include:
+
+- `themis_agent_run_seconds_bucket` – histogram buckets describing agent execution latency.
+- `themis_agent_tool_invocations_total` – counter of tool calls made by each agent.
+- `themis_agent_run_errors_total` – counter of run failures, useful for alerting.
+
+Unit coverage for the metrics registry and endpoint lives in `tests/test_metrics.py` (`pytest tests/test_metrics.py`).
 
 ---
 

--- a/agents/base.py
+++ b/agents/base.py
@@ -2,8 +2,29 @@
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
+from time import perf_counter
 from typing import Any, Protocol
+
+from tools.metrics import metrics_registry
+
+
+logger = logging.getLogger("themis.agents")
+
+_RUN_DURATION = metrics_registry.histogram(
+    "themis_agent_run_seconds",
+    "Wall clock duration for agent run executions.",
+    buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+)
+_TOOL_INVOCATIONS = metrics_registry.counter(
+    "themis_agent_tool_invocations_total",
+    "Number of tool invocations performed by an agent.",
+)
+_RUN_ERRORS = metrics_registry.counter(
+    "themis_agent_run_errors_total",
+    "Count of agent runs that raised an exception.",
+)
 
 
 class AgentProtocol(Protocol):
@@ -22,11 +43,62 @@ class BaseAgent(ABC):
 
     def __init__(self, name: str) -> None:
         self.name = name
+        self.tools: dict[str, Any] = {}
+        self._tool_invocations = 0
+
+    async def run(self, matter: dict[str, Any]) -> dict[str, Any]:
+        """Execute the agent logic with structured logging and metrics."""
+
+        logger.info(
+            "agent_run_start",
+            extra={"event": "agent_run_start", "agent": self.name},
+        )
+
+        start = perf_counter()
+        self._tool_invocations = 0
+        try:
+            result = await self._run(matter)
+        except Exception:
+            _RUN_ERRORS.inc(agent=self.name)
+            logger.exception(
+                "agent_run_error",
+                extra={"event": "agent_run_error", "agent": self.name},
+            )
+            raise
+        else:
+            return result
+        finally:
+            duration = perf_counter() - start
+            _RUN_DURATION.observe(duration, agent=self.name)
+            _TOOL_INVOCATIONS.inc(value=self._tool_invocations, agent=self.name)
+            logger.info(
+                "agent_run_complete",
+                extra={
+                    "event": "agent_run_complete",
+                    "agent": self.name,
+                    "duration": duration,
+                    "tool_invocations": self._tool_invocations,
+                },
+            )
 
     @abstractmethod
-    async def run(self, matter: dict[str, Any]) -> dict[str, Any]:
+    async def _run(self, matter: dict[str, Any]) -> dict[str, Any]:
         """Execute the agent logic."""
         raise NotImplementedError
+
+    def _call_tool(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        """Invoke a named tool while recording structured telemetry."""
+
+        if name not in getattr(self, "tools", {}):
+            raise KeyError(f"Tool '{name}' is not registered for agent {self.name}.")
+
+        logger.info(
+            "agent_tool_invocation",
+            extra={"event": "agent_tool_invocation", "agent": self.name, "tool": name},
+        )
+        self._tool_invocations += 1
+        tool = self.tools[name]
+        return tool(*args, **kwargs)
 
     def _build_response(
         self,

--- a/agents/dea.py
+++ b/agents/dea.py
@@ -24,11 +24,11 @@ class DEAAgent(BaseAgent):
             missing_csv = ", ".join(missing)
             raise ValueError(f"Missing required tools for DEA agent: {missing_csv}")
 
-    async def run(self, matter: dict[str, Any]) -> dict[str, Any]:
+    async def _run(self, matter: dict[str, Any]) -> dict[str, Any]:
         """Derive legal issues and map them to supporting authorities."""
 
-        spotted_issues = self.tools["issue_spotter"](matter)
-        citations = self.tools["citation_retriever"](matter, spotted_issues)
+        spotted_issues = self._call_tool("issue_spotter", matter)
+        citations = self._call_tool("citation_retriever", matter, spotted_issues)
 
         unresolved: list[str] = []
         if not spotted_issues:

--- a/agents/lda.py
+++ b/agents/lda.py
@@ -25,11 +25,11 @@ class LDAAgent(BaseAgent):
             missing_csv = ", ".join(missing)
             raise ValueError(f"Missing required tools for LDA agent: {missing_csv}")
 
-    async def run(self, matter: dict[str, Any]) -> dict[str, Any]:
+    async def _run(self, matter: dict[str, Any]) -> dict[str, Any]:
         """Derive a structured fact summary from the provided matter."""
 
-        parsed_documents = self.tools["document_parser"](matter)
-        timeline = self.tools["timeline_builder"](matter, parsed_documents)
+        parsed_documents = self._call_tool("document_parser", matter)
+        timeline = self._call_tool("timeline_builder", matter, parsed_documents)
 
         key_facts: list[str] = []
         for doc in parsed_documents:

--- a/agents/lsa.py
+++ b/agents/lsa.py
@@ -24,11 +24,11 @@ class LSAAgent(BaseAgent):
             missing_csv = ", ".join(missing)
             raise ValueError(f"Missing required tools for LSA agent: {missing_csv}")
 
-    async def run(self, matter: dict[str, Any]) -> dict[str, Any]:
+    async def _run(self, matter: dict[str, Any]) -> dict[str, Any]:
         """Combine facts and legal theories into a strategy recommendation."""
 
-        strategy = self.tools["strategy_template"](matter)
-        risks = self.tools["risk_assessor"](matter, strategy)
+        strategy = self._call_tool("strategy_template", matter)
+        risks = self._call_tool("risk_assessor", matter, strategy)
 
         unresolved: list[str] = []
         if not strategy.get("objectives"):

--- a/api/main.py
+++ b/api/main.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
 
 from orchestrator.router import configure_service, router as orchestrator_router
 from orchestrator.service import OrchestratorService
+from tools.metrics import metrics_registry
 
 app = FastAPI(title="Themis Orchestrator API")
 
@@ -25,3 +27,10 @@ app.include_router(orchestrator_router, prefix="/orchestrator", tags=["orchestra
 async def healthcheck() -> dict[str, str]:
     """Basic readiness probe for container orchestration."""
     return {"status": "ok"}
+
+
+@app.get("/metrics", tags=["system"], response_class=PlainTextResponse)
+async def metrics() -> PlainTextResponse:
+    """Expose collected metrics in Prometheus text format."""
+
+    return PlainTextResponse(content=metrics_registry.render(), media_type="text/plain; version=0.0.4")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,65 @@
+"""Shared pytest fixtures for the test suite."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+import pytest
+
+
+@pytest.fixture()
+def sample_matter() -> dict[str, Any]:
+    """Representative payload shared across agent scenarios."""
+
+    return {
+        "summary": "Alice retained counsel after Bob failed to deliver contracted goods.",
+        "parties": ["Alice", "Bob"],
+        "documents": [
+            {
+                "title": "Master Supply Agreement",
+                "content": "Agreement executed on 2023-01-15 for delivery of custom parts.",
+                "facts": [
+                    "Alice and Bob entered a supply contract on 2023-01-15.",
+                    "Bob agreed to deliver custom parts by March 1, 2023.",
+                ],
+                "date": "2023-01-15",
+            },
+            {
+                "title": "Notice of Breach",
+                "summary": "Alice notified Bob of material breach due to non-delivery on March 5, 2023.",
+                "facts": [
+                    "Alice provided written breach notice on March 5, 2023.",
+                    "Bob did not cure within 10 days of notice.",
+                ],
+                "date": "2023-03-05",
+            },
+        ],
+        "events": [
+            {"date": "2023-01-15", "description": "Contract executed."},
+            {"date": "2023-03-01", "description": "Delivery deadline passes without shipment."},
+            {"date": "2023-03-05", "description": "Notice of breach sent."},
+        ],
+        "issues": [
+            {
+                "issue": "Breach of contract",
+                "facts": ["Failure to deliver goods by the contractual deadline."],
+            },
+            "Damages for lost production time",
+        ],
+        "authorities": [
+            {"cite": "Restatement (Second) of Contracts § 235", "summary": "Non-performance is breach."},
+            "U.C.C. § 2-601",
+        ],
+        "goals": {
+            "settlement": "Recover $50,000 and secure expedited replacement parts.",
+            "fallback": "Seek partial refund and future discount.",
+        },
+        "strengths": ["Clear written agreement", "Prompt breach notice"],
+        "weaknesses": ["Limited documentation of consequential damages"],
+        "concessions": ["Extended delivery schedule if partial payment made."],
+        "evidentiary_gaps": ["Need expert report on downtime losses."],
+        "counterparty": "Bob's Fabrication LLC",
+        "confidence_score": 72,
+    }
+

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -8,69 +8,11 @@ from typing import Any
 
 import sys
 
-import pytest
-
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from agents.dea import DEAAgent
 from agents.lda import LDAAgent
 from agents.lsa import LSAAgent
-
-
-@pytest.fixture()
-def sample_matter() -> dict[str, object]:
-    """Representative payload shared across agent scenarios."""
-
-    return {
-        "summary": "Alice retained counsel after Bob failed to deliver contracted goods.",
-        "parties": ["Alice", "Bob"],
-        "documents": [
-            {
-                "title": "Master Supply Agreement",
-                "content": "Agreement executed on 2023-01-15 for delivery of custom parts.",
-                "facts": [
-                    "Alice and Bob entered a supply contract on 2023-01-15.",
-                    "Bob agreed to deliver custom parts by March 1, 2023.",
-                ],
-                "date": "2023-01-15",
-            },
-            {
-                "title": "Notice of Breach",
-                "summary": "Alice notified Bob of material breach due to non-delivery on March 5, 2023.",
-                "facts": [
-                    "Alice provided written breach notice on March 5, 2023.",
-                    "Bob did not cure within 10 days of notice.",
-                ],
-                "date": "2023-03-05",
-            },
-        ],
-        "events": [
-            {"date": "2023-01-15", "description": "Contract executed."},
-            {"date": "2023-03-01", "description": "Delivery deadline passes without shipment."},
-            {"date": "2023-03-05", "description": "Notice of breach sent."},
-        ],
-        "issues": [
-            {
-                "issue": "Breach of contract",
-                "facts": ["Failure to deliver goods by the contractual deadline."],
-            },
-            "Damages for lost production time",
-        ],
-        "authorities": [
-            {"cite": "Restatement (Second) of Contracts § 235", "summary": "Non-performance is breach."},
-            "U.C.C. § 2-601",
-        ],
-        "goals": {
-            "settlement": "Recover $50,000 and secure expedited replacement parts.",
-            "fallback": "Seek partial refund and future discount.",
-        },
-        "strengths": ["Clear written agreement", "Prompt breach notice"],
-        "weaknesses": ["Limited documentation of consequential damages"],
-        "concessions": ["Extended delivery schedule if partial payment made."],
-        "evidentiary_gaps": ["Need expert report on downtime losses."],
-        "counterparty": "Bob's Fabrication LLC",
-        "confidence_score": 72,
-    }
 
 
 def test_lda_agent_schema(sample_matter: dict[str, object]) -> None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,52 @@
+"""Tests for the metrics registry and FastAPI exposition endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+
+from agents.lda import LDAAgent
+from api.main import metrics as metrics_endpoint
+from tools.metrics import metrics_registry
+
+
+def test_agent_run_metrics_recorded(sample_matter: dict[str, object]) -> None:
+    """Ensure agent runs produce duration and tool invocation metrics."""
+
+    metrics_registry.reset()
+
+    asyncio.run(LDAAgent().run(sample_matter))
+
+    duration_histogram = metrics_registry.get_histogram("themis_agent_run_seconds")
+    assert duration_histogram is not None
+
+    samples = list(duration_histogram.samples())
+    assert samples, "Expected histogram samples for LDA agent run"
+    labels, _, _, count = samples[0]
+    assert labels.get("agent") == "lda"
+    assert count == 1
+
+    tool_counter = metrics_registry.get_counter("themis_agent_tool_invocations_total")
+    assert tool_counter is not None
+
+    tool_samples = list(tool_counter.samples())
+    lda_sample = next(
+        (value for sample_labels, value in tool_samples if sample_labels.get("agent") == "lda"),
+        None,
+    )
+    assert lda_sample is not None
+    assert lda_sample >= 2
+
+
+def test_metrics_endpoint_prometheus_output(sample_matter: dict[str, object]) -> None:
+    """The /metrics endpoint should return scrape-compatible text."""
+
+    metrics_registry.reset()
+    asyncio.run(LDAAgent().run(sample_matter))
+
+    response = asyncio.run(metrics_endpoint())
+
+    assert response.status_code == 200
+    body = response.body.decode()
+    assert "themis_agent_run_seconds_bucket" in body
+    assert 'agent="lda"' in body
+    assert body.endswith("\n")

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -1,0 +1,172 @@
+"""In-memory metrics registry with Prometheus exposition support."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Iterable, Iterator
+
+
+def _escape_label_value(value: Any) -> str:
+    text = str(value)
+    return text.replace("\\", r"\\").replace("\n", r"\n").replace('"', r"\"")
+
+
+def _format_labels(labels: dict[str, Any]) -> str:
+    if not labels:
+        return ""
+    parts = [f'{key}="{_escape_label_value(value)}"' for key, value in sorted(labels.items())]
+    return "{" + ",".join(parts) + "}"
+
+
+class CounterMetric:
+    """Simple monotonically increasing counter."""
+
+    def __init__(self, name: str, description: str) -> None:
+        self.name = name
+        self.description = description
+        self._values: dict[tuple[tuple[str, Any], ...], float] = defaultdict(float)
+
+    def inc(self, value: float = 1.0, **labels: Any) -> None:
+        """Increment the counter for the provided label set."""
+
+        key = tuple(sorted(labels.items()))
+        self._values[key] += value
+
+    def samples(self) -> Iterator[tuple[dict[str, Any], float]]:
+        for key, value in self._values.items():
+            yield dict(key), value
+
+    def render(self) -> list[str]:
+        lines = [f"# HELP {self.name} {self.description}", f"# TYPE {self.name} counter"]
+        for labels, value in sorted(
+            self.samples(), key=lambda item: tuple(sorted(item[0].items()))
+        ):
+            lines.append(f"{self.name}{_format_labels(labels)} {value}")
+        if len(lines) == 2:
+            # Counters should still emit a zero sample to ensure discoverability.
+            lines.append(f"{self.name} 0")
+        return lines
+
+    def reset(self) -> None:
+        self._values.clear()
+
+
+@dataclass
+class _HistogramSample:
+    bucket_counts: list[int]
+    value_sum: float = 0.0
+    value_count: int = 0
+
+
+class HistogramMetric:
+    """Fixed-bucket histogram compatible with Prometheus exposition."""
+
+    def __init__(self, name: str, description: str, buckets: Iterable[float]) -> None:
+        bucket_list = sorted(float(bucket) for bucket in buckets)
+        if not bucket_list:
+            raise ValueError("Histogram requires at least one bucket boundary")
+        if bucket_list[-1] != float("inf"):
+            bucket_list.append(float("inf"))
+        self.name = name
+        self.description = description
+        self._buckets = bucket_list
+        self._values: dict[tuple[tuple[str, Any], ...], _HistogramSample] = {}
+
+    def observe(self, value: float, **labels: Any) -> None:
+        """Record an observation for the provided label set."""
+
+        key = tuple(sorted(labels.items()))
+        sample = self._values.setdefault(
+            key, _HistogramSample(bucket_counts=[0 for _ in self._buckets])
+        )
+        for index, upper in enumerate(self._buckets):
+            if value <= upper:
+                sample.bucket_counts[index] += 1
+        sample.value_sum += value
+        sample.value_count += 1
+
+    def samples(
+        self,
+    ) -> Iterator[tuple[dict[str, Any], list[int], float, int]]:
+        for key, sample in self._values.items():
+            yield dict(key), sample.bucket_counts, sample.value_sum, sample.value_count
+
+    def render(self) -> list[str]:
+        lines = [f"# HELP {self.name} {self.description}", f"# TYPE {self.name} histogram"]
+        for labels, bucket_counts, value_sum, value_count in sorted(
+            self.samples(), key=lambda item: tuple(sorted(item[0].items()))
+        ):
+            cumulative = 0
+            for upper, bucket_value in zip(self._buckets, bucket_counts):
+                cumulative = bucket_value
+                upper_label = "+Inf" if upper == float("inf") else str(upper)
+                bucket_labels = labels | {"le": upper_label}
+                lines.append(
+                    f"{self.name}_bucket{_format_labels(bucket_labels)} {cumulative}"
+                )
+            lines.append(f"{self.name}_count{_format_labels(labels)} {value_count}")
+            lines.append(f"{self.name}_sum{_format_labels(labels)} {value_sum}")
+        if len(lines) == 2:
+            # Emit empty histogram to satisfy Prometheus scrapes.
+            for upper in self._buckets:
+                upper_label = "+Inf" if upper == float("inf") else str(upper)
+                bucket_labels = {"le": upper_label}
+                lines.append(f"{self.name}_bucket{_format_labels(bucket_labels)} 0")
+            lines.append(f"{self.name}_count 0")
+            lines.append(f"{self.name}_sum 0")
+        return lines
+
+    def reset(self) -> None:
+        self._values.clear()
+
+
+class MetricsRegistry:
+    """Container for counters and histograms exposed via the API."""
+
+    def __init__(self) -> None:
+        self._counters: dict[str, CounterMetric] = {}
+        self._histograms: dict[str, HistogramMetric] = {}
+
+    def counter(self, name: str, description: str) -> CounterMetric:
+        if name not in self._counters:
+            self._counters[name] = CounterMetric(name, description)
+        return self._counters[name]
+
+    def histogram(
+        self, name: str, description: str, *, buckets: Iterable[float]
+    ) -> HistogramMetric:
+        if name not in self._histograms:
+            self._histograms[name] = HistogramMetric(name, description, buckets)
+        return self._histograms[name]
+
+    def get_counter(self, name: str) -> CounterMetric | None:
+        return self._counters.get(name)
+
+    def get_histogram(self, name: str) -> HistogramMetric | None:
+        return self._histograms.get(name)
+
+    def render(self) -> str:
+        lines: list[str] = []
+        for metric in self._counters.values():
+            lines.extend(metric.render())
+        for metric in self._histograms.values():
+            lines.extend(metric.render())
+        return "\n".join(lines) + "\n"
+
+    def reset(self) -> None:
+        for metric in self._counters.values():
+            metric.reset()
+        for metric in self._histograms.values():
+            metric.reset()
+
+
+metrics_registry = MetricsRegistry()
+
+__all__ = [
+    "CounterMetric",
+    "HistogramMetric",
+    "MetricsRegistry",
+    "metrics_registry",
+]
+


### PR DESCRIPTION
## Summary
- wrap agent execution with structured logging and record durations, failures, and tool usage
- add an in-memory metrics registry with Prometheus rendering and expose the /metrics API endpoint
- document scrape instructions and cover the new telemetry with dedicated unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f6670ca7e88332ae54f12f3c5f92e6