### PR TITLE
Add PI demand fixtures and integration coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+PYTHON ?= python3
+
+.PHONY: test
+
+test:
+	$(PYTHON) -m pytest

--- a/README.md
+++ b/README.md
@@ -143,6 +143,21 @@ Implement the `AgentProtocol` (see `agents/base.py`) and register the agent in t
 2. Author QA scenarios in `qa/<pack_name>/`.
 3. Run `make qa PACK=<pack_name>` to validate.
 
+### Refreshing PI Demand Fixtures
+
+The PI demand pack ships with curated matter payloads in `packs/pi_demand/fixtures/`. Integration coverage (`tests/packs/test_pi_demand.py`) runs the full orchestrator pipeline against these payloads and verifies the generated timeline and demand letter artifacts.
+
+When the orchestrator schema or expected artifacts evolve:
+
+1. Update each fixture (for example `nominal_collision_matter.json` or `edgecase_sparse_slip_and_fall.json`) so the payload reflects the new schema.
+2. Execute the pack locally to confirm the orchestrator accepts the changes:
+
+   ```bash
+   python -m packs.pi_demand.run --matter packs/pi_demand/fixtures/nominal_collision_matter.json
+   ```
+
+3. Regenerate artifacts or adjust assertions as needed, then run `make test` to ensure the integration suite reflects the refreshed schema.
+
 ---
 
 ## Observability & Metrics

--- a/packs/pi_demand/fixtures/edgecase_sparse_slip_and_fall.json
+++ b/packs/pi_demand/fixtures/edgecase_sparse_slip_and_fall.json
@@ -1,0 +1,43 @@
+{
+  "matter": {
+    "metadata": {
+      "id": "PI-2024-CHEN",
+      "title": "Chen v. Sunrise Market"
+    },
+    "summary": "Maya Chen slipped on a puddle near the produce misters at Sunrise Market on February 11, 2024, injuring her right ankle and wrist.",
+    "description": "Client reported no warning cones or signage and noted that employees had been mopping minutes earlier.",
+    "parties": [
+      "Maya Chen",
+      "Sunrise Market LLC"
+    ],
+    "documents": [
+      {
+        "title": "Store Incident Report",
+        "date": "2024-02-11",
+        "summary": "Assistant manager recorded moisture buildup beneath the produce display and acknowledged prior customer complaints about slick tiles.",
+        "facts": [
+          "CCTV footage captured the fall and delayed response by staff."
+        ]
+      }
+    ],
+    "issues": [
+      "Premises liability – failure to maintain safe conditions"
+    ],
+    "authorities": [],
+    "events": [],
+    "goals": {
+      "settlement": "$45,000"
+    },
+    "strengths": [
+      "Store emails show earlier complaints about the same hazard."
+    ],
+    "weaknesses": [
+      "Client delayed seeking treatment for five days."
+    ],
+    "concessions": [],
+    "evidentiary_gaps": [
+      "Need maintenance logs for the week preceding the fall."
+    ],
+    "confidence_score": "58"
+  }
+}

--- a/packs/pi_demand/fixtures/nominal_collision_matter.json
+++ b/packs/pi_demand/fixtures/nominal_collision_matter.json
@@ -1,0 +1,103 @@
+{
+  "matter": {
+    "metadata": {
+      "id": "PI-2024-LOPEZ",
+      "title": "Lopez v. Coastal Delivery"
+    },
+    "summary": "Maria Lopez suffered shoulder and knee injuries when a Coastal Delivery van merged into the bike lane and forced her into oncoming traffic on April 18, 2024. She continues to struggle with range of motion and balance required for her work as a dance instructor.",
+    "parties": [
+      "Maria Lopez (Client)",
+      "Coastal Delivery LLC"
+    ],
+    "counterparty": "Claims Specialist for Coastal Delivery",
+    "documents": [
+      {
+        "title": "Traffic Collision Report",
+        "date": "2024-04-18",
+        "summary": "Officer Nguyen documented that the Coastal Delivery driver failed to check blind spots prior to merging into the bike lane, striking Ms. Lopez and causing her to collide with a parked vehicle.",
+        "facts": [
+          "Driver admitted to rushing to complete deliveries before the lunch window.",
+          "Witnesses confirmed Ms. Lopez had a green cycling signal."
+        ]
+      },
+      {
+        "title": "Orthopedic Evaluation",
+        "date": "2024-05-01",
+        "summary": "Dr. Ibrahim diagnosed a torn rotator cuff and patellar tracking issues. Treatment plan calls for arthroscopic surgery and six months of physical therapy.",
+        "facts": [
+          "MRI confirms full-thickness supraspinatus tear.",
+          "Surgeon recommends post-operative therapy three times per week."
+        ]
+      },
+      {
+        "title": "Vocational Loss Assessment",
+        "date": "2024-06-12",
+        "summary": "Economic expert projects $42,000 in lost performance income and studio refunds over the next twelve months.",
+        "facts": [
+          "Cancelled workshops created $18,000 in refunds owed to clients.",
+          "Studio assistant payroll increased by $2,800 to cover missed classes."
+        ]
+      }
+    ],
+    "events": [
+      {
+        "date": "2024-04-18",
+        "description": "Collision at Embarcadero and Washington Street involving Coastal Delivery van."
+      },
+      {
+        "date": "2024-04-22",
+        "description": "Initial consultation and imaging with Dr. Ibrahim."
+      },
+      {
+        "date": "2024-06-05",
+        "description": "Coastal Delivery denies liability in email from claims specialist."
+      }
+    ],
+    "issues": [
+      {
+        "issue": "Negligence – failure to maintain safe lane change",
+        "facts": [
+          "Driver merged without clearing bike lane."
+        ]
+      },
+      {
+        "issue": "Damages – future medical and vocational losses",
+        "facts": [
+          "Surgery and extended therapy required to regain mobility."
+        ]
+      }
+    ],
+    "authorities": [
+      {
+        "cite": "Cal. Veh. Code § 22107",
+        "summary": "Requires drivers to execute lane changes safely without endangering others."
+      },
+      {
+        "cite": "CACI 3903D",
+        "summary": "Jury instruction on loss of earning capacity damages."
+      }
+    ],
+    "goals": {
+      "settlement": "$210,000",
+      "fallback": "$160,000"
+    },
+    "strengths": [
+      "Independent eyewitness corroborates liability.",
+      "Client maintained consistent treatment and documentation."
+    ],
+    "weaknesses": [
+      "Client missed two physical therapy sessions in May."
+    ],
+    "concessions": [
+      "Open to structured settlement that accelerates therapy budget."
+    ],
+    "evidentiary_gaps": [
+      "Pending updated cost estimate for post-surgery care."
+    ],
+    "confidence_score": 72,
+    "damages": {
+      "specials": 52000,
+      "generals": 118000
+    }
+  }
+}

--- a/tests/packs/test_pi_demand.py
+++ b/tests/packs/test_pi_demand.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+import csv
+from pathlib import Path
+
+import pytest
+
+from orchestrator.service import OrchestratorService
+from orchestrator.storage.sqlite_repository import SQLiteOrchestratorStateRepository
+from packs.pi_demand import run as pi_demand_run
+
+
+FIXTURE_DIR = Path(__file__).resolve().parents[2] / "packs" / "pi_demand" / "fixtures"
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "expected_phrases", "min_timeline_rows"),
+    [
+        (
+            "nominal_collision_matter.json",
+            [
+                "Subject: Settlement Demand",
+                "Maria Lopez suffered shoulder and knee injuries",
+                "Negotiation Positions:",
+                "$210,000",
+            ],
+            3,
+        ),
+        (
+            "edgecase_sparse_slip_and_fall.json",
+            [
+                "Subject: Settlement Demand",
+                "Maya Chen slipped on a puddle",
+                "Dear Opposing Counsel",
+                "Negotiation Positions:",
+            ],
+            1,
+        ),
+    ],
+)
+def test_pi_demand_pack_generates_artifacts(
+    tmp_path: Path, fixture_name: str, expected_phrases: list[str], min_timeline_rows: int
+) -> None:
+    matter_path = FIXTURE_DIR / fixture_name
+    matter = pi_demand_run.load_matter(matter_path)
+
+    database_url = f"sqlite:///{tmp_path / 'state.db'}"
+    repository = SQLiteOrchestratorStateRepository(database_url=database_url)
+    service = OrchestratorService(repository=repository)
+
+    execution = asyncio.run(service.execute(matter))
+
+    assert execution["status"] == "complete"
+    assert set(execution["artifacts"]) == {"lda", "dea", "lsa"}
+
+    saved_paths = pi_demand_run.persist_outputs(matter, execution, output_root=tmp_path)
+
+    matter_slug = matter["metadata"]["slug"]
+    matter_output_dir = tmp_path / matter_slug
+    timeline_file = matter_output_dir / "timeline.csv"
+    letter_file = matter_output_dir / "draft_demand_letter.txt"
+
+    assert timeline_file.exists()
+    assert letter_file.exists()
+    assert set(saved_paths) == {timeline_file, letter_file}
+
+    with timeline_file.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert len(rows) >= min_timeline_rows
+    assert all(row["description"].strip() for row in rows)
+
+    letter_content = letter_file.read_text(encoding="utf-8")
+    for phrase in expected_phrases:
+        assert phrase in letter_content
+
+    # Running persist_outputs again should be idempotent and not raise.
+    second_saved_paths = pi_demand_run.persist_outputs(matter, execution, output_root=tmp_path)
+    assert set(second_saved_paths) == {timeline_file, letter_file}


### PR DESCRIPTION
## Summary
- add nominal and edge-case PI demand fixtures and document how to refresh them
- implement an integration test that runs the PI demand pack against curated fixtures and verifies generated artifacts
- replace the SQLModel-based repository with a stdlib sqlite3 implementation and update persistence tests to run without async plugins
- add a Makefile `test` target that exercises the full pytest suite

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68f668bff2088332b431ab1234caf7ce